### PR TITLE
merge to v1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You should now be able to see the plugin list in Administration -> Plugins.
    
    You can also use e.g. cron.daily or cron.hourly to avoid having to figure out the precise cron syntax for the schedule; Ruby gems Rufus Scheduler and Whenever can also be used; the key point is that something needs to call recur_tasks on a regular basis.
 
-   More information on Rufus Scheduler config at ([#72](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/72))
+   More information on Rufus Scheduler config at [#72](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/72)
    
 2. Decide which role(s) should have the ability to view/add/edit/delete issue recurrence and configure accordingly in Redmine's permission manager (Administration > Roles and Permissions) 
    * View issue recurrence

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Follow standard Redmine plugin installation -- (barely) modified from http://www
 1. Copy or clone the plugin directory into #{RAILS_ROOT}/plugins/recurring_tasks -- note the folder name 'recurring_tasks' must be verbatim.
    
    e.g. git clone https://github.com/nutso/redmine-plugin-recurring-tasks.git recurring_tasks
+   
+   NOTE! This particular clone will tie you to the master branch, which is not recommended for production systems (faster updates and features but less well-tested). Recommend using a specific version of the plugin which will provide a more stable baseline. 
 
 2. Rake the database migration (make a db backup before)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You should now be able to see the plugin list in Administration -> Plugins.
    
    You can also use e.g. cron.daily or cron.hourly to avoid having to figure out the precise cron syntax for the schedule; Ruby gems Rufus Scheduler and Whenever can also be used; the key point is that something needs to call recur_tasks on a regular basis.
 
-   More information on Rufus Scheduler config at ([#72](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/72)
+   More information on Rufus Scheduler config at ([#72](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/72))
    
 2. Decide which role(s) should have the ability to view/add/edit/delete issue recurrence and configure accordingly in Redmine's permission manager (Administration > Roles and Permissions) 
    * View issue recurrence

--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ You should now be able to see the plugin list in Administration -> Plugins.
      
 1. Set the check for recurrence via Crontab.
 
-   Crontab example (running the check for recurrence every 6 hours on the 15s) -- replace {path_to_redmine} with your actual path, e.g. /var/www/redmine:
+   "Pure" crontab example (running the check for recurrence every 6 hours on the 15s) -- replace {path_to_redmine} with your actual path, e.g. /var/www/redmine:
    ```bash
    15 */4 * * * /bin/sh "cd {path_to_redmine} && bundle exec rake RAILS_ENV=production redmine:recur_tasks" >> log/cron_rake.log 2>&1
    ```
+   
+   You can also use e.g. cron.daily or cron.hourly to avoid having to figure out the precise cron syntax for the schedule.
    
 2. Decide which role(s) should have the ability to view/add/edit/delete issue recurrence and configure accordingly in Redmine's permission manager (Administration > Roles and Permissions) 
    * View issue recurrence

--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ You should now be able to see the plugin list in Administration -> Plugins.
      
 ## Configuration
      
-1. Set the check for recurrence via Crontab.
+1. Set the check for recurrence via Crontab or similar.
 
    "Pure" crontab example (running the check for recurrence every 6 hours on the 15s) -- replace {path_to_redmine} with your actual path, e.g. /var/www/redmine:
    ```bash
    15 */4 * * * /bin/sh "cd {path_to_redmine} && bundle exec rake RAILS_ENV=production redmine:recur_tasks" >> log/cron_rake.log 2>&1
    ```
    
-   You can also use e.g. cron.daily or cron.hourly to avoid having to figure out the precise cron syntax for the schedule.
+   You can also use e.g. cron.daily or cron.hourly to avoid having to figure out the precise cron syntax for the schedule; Ruby gems Rufus Scheduler and Whenever can also be used; the key point is that something needs to call recur_tasks on a regular basis.
+
+   More information on Rufus Scheduler config at ([#72](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/72)
    
 2. Decide which role(s) should have the ability to view/add/edit/delete issue recurrence and configure accordingly in Redmine's permission manager (Administration > Roles and Permissions) 
    * View issue recurrence

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,6 +5,7 @@
 * Option to 'predict' recurrences on calendar -- perhaps ghost the projected recurrences in ([#38](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/38))
 * Option to re-open recurring issue instead of creating a new issue, so all comments/information are stored in a single place ([#45](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/45)); ([#45](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/74))
 * Option to enable recurrence on a per-project basis ([#36](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/36))
+* Configurable option to hide the "Recurring issues" link in the admin menu ([#54](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/54))
 
 ## Known Issues
 
@@ -17,6 +18,7 @@
 * Better documentation of plugin permissions
 * Reversible migrations so can uninstall fully ([#53](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/53))
 * Highlighting to user that adding recurrence via issues page is the best way ([#52](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/52))
+* Support for Redmine 3  
 
 ## Version 1.4.0 (07 Sep 2014)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,7 +3,7 @@
 ## Features Requested
 
 * Option to 'predict' recurrences on calendar -- perhaps ghost the projected recurrences in ([#38](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/38))
-* Option to re-open recurring issue instead of creating a new issue, so all comments/information are stored in a single place ([#45](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/45))
+* Option to re-open recurring issue instead of creating a new issue, so all comments/information are stored in a single place ([#45](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/45)); ([#45](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/74))
 * Option to enable recurrence on a per-project basis ([#36](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/36))
 
 ## Known Issues

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,10 +11,10 @@
 
 * No ability to view historic recurrences
 * Deleting an issue does not provide a warning about deleting associated recurrences
-* v1.4 is the stable version to use for Redmine 2.x for now; master will continue to support Redmine 2.x and 3.x but Redmine 2 in master is broken
-
 
 ## Next Version (Develop Branch)
+
+## Version 1.5.0 (13 June 2015)
 
 * Backwards-compatibility to Redmine 2.2 by testing if issue.closed_on? method exists ([#49](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/36))
 * Better documentation of plugin permissions

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,10 @@
 
 * No ability to view historic recurrences
 * Deleting an issue does not provide a warning about deleting associated recurrences
+* v1.4 is the stable version to use for Redmine 2.x for now; master will continue to support Redmine 2.x and 3.x but Redmine 2 in master is broken
+
+## Semi-Stable (Master Branch)
+* Support for Redmine 3 and rails 4 ([#67](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/67)) and ([#69](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/69))
 
 ## Next Version (Develop Branch)
 
@@ -18,7 +22,7 @@
 * Better documentation of plugin permissions
 * Reversible migrations so can uninstall fully ([#53](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/53))
 * Highlighting to user that adding recurrence via issues page is the best way ([#52](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/52))
-* Support for Redmine 3  
+* 
 
 ## Version 1.4.0 (07 Sep 2014)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -13,8 +13,6 @@
 * Deleting an issue does not provide a warning about deleting associated recurrences
 * v1.4 is the stable version to use for Redmine 2.x for now; master will continue to support Redmine 2.x and 3.x but Redmine 2 in master is broken
 
-## Semi-Stable (Master Branch)
-* Support for Redmine 3 and rails 4 ([#67](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/67)) and ([#69](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/69))
 
 ## Next Version (Develop Branch)
 
@@ -22,7 +20,7 @@
 * Better documentation of plugin permissions
 * Reversible migrations so can uninstall fully ([#53](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/53))
 * Highlighting to user that adding recurrence via issues page is the best way ([#52](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/52))
-* 
+* Stable support for both Redmine 2.x and Redmine 3.x ([#71](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/71)); ([#67](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/67)) and ([#69](https://github.com/nutso/redmine-plugin-recurring-tasks/issues/69))
 
 ## Version 1.4.0 (07 Sep 2014)
 

--- a/app/models/recurring_task.rb
+++ b/app/models/recurring_task.rb
@@ -249,7 +249,13 @@ class RecurringTask < ActiveRecord::Base
       new_issue.due_date = next_scheduled_recurrence #41 previous_date_for_recurrence + recurrence_pattern
       new_issue.start_date = new_issue.due_date
       new_issue.done_ratio = 0
-      new_issue.status = issue.tracker.default_status # issue status is NOT automatically new, default is whatever the default status for new issues is
+      if issue.tracker.respond_to?(:default_status)
+        # Redmine 3
+        new_issue.status = issue.tracker.default_status # issue status is NOT automatically new, default is whatever the default status for new issues is
+      else
+        # Redmine 2
+        new_issue.status = IssueStatus.default
+      end
       new_issue.save!
       puts "Recurring #{issue.id}: #{issue.subj_date}, created #{new_issue.id}: #{new_issue.subj_date}"
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ match 'projects/:project_id/recurring_tasks/new(/:issue_id)', :to => 'recurring_
 match 'projects/:project_id/recurring_tasks/create', :to => 'recurring_tasks#create', :via => 'post'
 match 'projects/:project_id/recurring_tasks/:id', :to => 'recurring_tasks#show', :as => :recurring_task, :via => 'get'
 match 'projects/:project_id/recurring_tasks/:id/edit', :to => 'recurring_tasks#edit', :as => :edit_recurring_task, :via => 'get'
-match 'projects/:project_id/recurring_tasks/:id/update', :to => 'recurring_tasks#update', :via => [:get, :post, :patch]
-match 'projects/:project_id/recurring_tasks/:id/destroy', :to => 'recurring_tasks#destroy', :as => :destroy_recurring_task, :via => [:post, :delete]
+match 'projects/:project_id/recurring_tasks/:id/update', :to => 'recurring_tasks#update', :via => [:put, :patch]
+match 'projects/:project_id/recurring_tasks/:id/destroy', :to => 'recurring_tasks#destroy', :as => :destroy_recurring_task, :via => [:delete]

--- a/db/migrate/004_set_default_modifier_for_existing_monthly_issues.rb
+++ b/db/migrate/004_set_default_modifier_for_existing_monthly_issues.rb
@@ -2,7 +2,9 @@
 # default modifier for existing issues. Otherwise validation error will occur.
 class SetDefaultModifierForExistingMonthlyIssues < ActiveRecord::Migration
   def up
-    RecurringTask.find_all_by_interval_unit(RecurringTask::INTERVAL_MONTH).each do |rt|
+    # find_all_by... deprecated for Rails 4/Redmine 3
+    # RecurringTask.find_all_by_interval_unit(RecurringTask::INTERVAL_MONTH).each do |rt|
+    RecurringTask.where(:interval_unit => RecurringTask::INTERVAL_MONTH).each do |rt|
       begin
         logger.info "Migrating task ##{rt.id}, interval unit #{rt.interval_unit}"
         rt.interval_modifier = RecurringTask::MONTH_MODIFIER_DAY_FROM_FIRST

--- a/init.rb
+++ b/init.rb
@@ -9,8 +9,8 @@ Redmine::Plugin.register :recurring_tasks do
   author 'Teresa N.'
   author_url 'https://github.com/nutso/'
   url 'https://github.com/nutso/redmine-plugin-recurring-tasks'
-  description 'Allows you to set a task to recur on a regular schedule, or when marked complete, regenerate a new task due in the future. Plugin is based -- very loosely -- on the periodic tasks plugin published by Tanguy de Courson'
-  version '1.4.0'
+  description 'Allows you to set a task to recur on a regular schedule, or when marked complete, regenerate a new task due in the future. Supports Redmine 2.x and 3.x'
+  version '1.5.0'
   
   Redmine::MenuManager.map :top_menu do |menu|
     menu.push :recurring_tasks, { :controller => 'recurring_tasks', :action => 'index' }, :caption => :label_recurring_tasks, :if => Proc.new { User.current.admin? }


### PR DESCRIPTION
* Backwards-compatibility to Redmine 2.2 by testing if issue.closed_on? method exists (#49)
* Better documentation of plugin permissions
* Reversible migrations so can uninstall fully (#53)
* Highlighting to user that adding recurrence via issues page is the best way (#52)
* Stable support for both Redmine 2.x and Redmine 3.x (#71); (#67) and (#69)