### PR TITLE
Display localised date

### DIFF
--- a/app/views/issues/_show_recurrence.html.erb
+++ b/app/views/issues/_show_recurrence.html.erb
@@ -14,7 +14,7 @@
               <%= link_to(rt.recurrence_to_s, edit_recurring_task_path(:id => rt.id, :project_id => project.id)) %>
             </td>
             <td>
-              <%= "#{l(:label_next_scheduled_run)}: #{rt.next_scheduled_recurrence}" %>
+              <%= "#{l(:label_next_scheduled_run)}: " %><%= format_date(rt.next_scheduled_recurrence) %>
             </td>
             <td class="buttons">
               <%= link_to(l(:button_edit), edit_recurring_task_path(:id => rt.id, :project_id => project.id), :class => 'icon icon-edit') %>


### PR DESCRIPTION
This uses `format_date` in the issue detail page like it is done in the list overview, too.