### PR TITLE
Fix/remove unused methods

### DIFF
--- a/app/models/recurring_task.rb
+++ b/app/models/recurring_task.rb
@@ -313,10 +313,6 @@ class RecurringTask < ActiveRecord::Base
     "#{i} (#{l(:label_recurrence_pattern)} #{interval_number} #{interval_unit}s " + (:fixed_schedule ? l(:label_recurs_fixed) : l(:label_recurs_dependent)) + ")"
   end
   
-  def to_s_long
-    "#{to_s}. #{l(:label_belongs_to_project)} #{:issue.project}. #{l(:label_assigned_to)} #{:issue.assigned_to_id}"
-  end
-  
   # for each recurring task, check whether to create a new one
   def self.add_recurrences!
     RecurringTask.all.each do |task|

--- a/app/models/recurring_task.rb
+++ b/app/models/recurring_task.rb
@@ -165,13 +165,6 @@ class RecurringTask < ActiveRecord::Base
     Hash[MONTH_MODIFIERS_LOCALIZED.map{|k,v| [k, v % values]}]
   end
   
-  
-  
-  def self.find_by_issue issue
-    # it's possible there is more than one recurrence associated with an issue
-    RecurringTask.where(:current_issue_id => issue.id)
-  end
-  
   # retrieve all recurring tasks given a project
   def self.all_for_project project
     if project.nil? then all else RecurringTask.includes(:issue).where("issues.project_id" => project.id) end

--- a/lib/issues_patch.rb
+++ b/lib/issues_patch.rb
@@ -14,10 +14,6 @@ module RecurringTasks
           !(recurring_tasks.nil? || recurring_tasks.length <= 0)
           # TODO determine if it was a historically recurring task
         end
-        
-        #def recurring_tasks
-        #  RecurringTask.find_by_issue(self)
-        #end
       end # base.class_eval
     end # self.included
   end # issues patch


### PR DESCRIPTION
When reading the source to see how the gem works I ran into two unused methods:

`#to_s_long` seems to be completely unused, it was added in the initial commit, but even then it was never used. I guess it's a leftover of initial development.

`.find_by_issue` was used before but no more since the #33 fixes
