### PR TITLE
Feature: Working day recurrence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ rerun.txt
 pickle-email-*.html
 .project
 config/initializers/secret_token.rb
+redmine/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+group :test do
+  gem 'timecop'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  specs:
+    timecop (0.7.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  timecop
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -96,3 +96,24 @@ Follow standard Redmine plugin un-installation -- (barely) modified from http://
 2. Remove the plugin from the plugins folder (#{RAILS_ROOT}/plugins)
 
 3. Restart Redmine (or web server)
+
+## Running the tests
+
+1. Copy Redmine to `redmine/`:
+   - `curl -O http://www.redmine.org/releases/redmine-3.1.1.tar.gz`
+   - `tar -xf redmine-3.1.1.tar.gz`
+   - `rm redmine-3.1.1.tar.gz`
+   - `mv redmine-3.1.1 redmine`
+2. Symlink the plugin into the plugins folder:
+   - `ln -s ../.. redmine/plugins/recurring_tasks`
+3. Setup a default database
+   - `ln -s ../../test/database.yml redmine/config/database.yml`
+   - `cd redmine`
+   - `rake db:create`
+   - `rake db:migrate RAILS_ENV=test`
+4. Install required gems by Redmine
+   - `bundle`
+5. Go back to the plugin folder
+   - `cd ..`
+6. And run the tests
+   - `rake`

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+require 'rake'
+require 'rake/testtask'
+require 'rdoc/task'
+
+desc 'Default: run unit tests'
+task :default => :test
+
+desc 'Test redmine-plugin-recurring-tasks'
+Rake::TestTask.new :test do |t|
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = true
+end

--- a/app/models/recurring_task.rb
+++ b/app/models/recurring_task.rb
@@ -360,11 +360,11 @@ private
     elsif fixed_schedule and !issue.due_date.nil? 
       issue.due_date
     elsif !issue.respond_to?('closed_on') # closed_on introduced in Redmine 2.3, ref http://www.redmine.org/issues/824
-      issue.updated_on
+      issue.updated_on.to_date
     elsif issue.closed_on.nil? 
-      issue.updated_on
+      issue.updated_on.to_date
     else 
-      issue.closed_on 
+      issue.closed_on.to_date
     end
   end
 end

--- a/app/models/recurring_task.rb
+++ b/app/models/recurring_task.rb
@@ -1,5 +1,6 @@
 class RecurringTask < ActiveRecord::Base
   unloadable
+  include Redmine::Utils::DateCalculation
 
   belongs_to :issue, :foreign_key => 'current_issue_id'
   has_one :project, :through => :issue
@@ -17,6 +18,9 @@ class RecurringTask < ActiveRecord::Base
   # similar flags for denoting more complex recurrence schemes
   # they are modyfing how due dates are scheduled when INTERVAL_MONTH is in
   # effect
+  DAY_MODIFIER_ALL = 'da'
+  DAY_MODIFIER_WORKING_DAYS = 'dwd'
+
   MONTH_MODIFIER_DAY_FROM_FIRST = 'mdff'
   MONTH_MODIFIER_DAY_TO_LAST = 'mdtl'
   MONTH_MODIFIER_DOW_FROM_FIRST = 'mdowff'
@@ -31,6 +35,12 @@ class RecurringTask < ActiveRecord::Base
     INTERVAL_MONTH => l(:interval_month),
     INTERVAL_YEAR => l(:interval_year)
   }
+
+  DAY_MODIFIERS_LOCALIZED = {
+    DAY_MODIFIER_ALL => l(:day_modifier_all),
+    DAY_MODIFIER_WORKING_DAYS => l(:day_modifier_working_days)
+  }
+
   MONTH_MODIFIERS_LOCALIZED = {
     MONTH_MODIFIER_DAY_FROM_FIRST => l(:month_modifier_day_from_first),
     MONTH_MODIFIER_DAY_TO_LAST => l(:month_modifier_day_to_last),
@@ -43,7 +53,7 @@ class RecurringTask < ActiveRecord::Base
   # for older Rails compatibility
   # validates_presence_of :interval_localized_name #41
   validates_presence_of :interval_unit
-  validates_presence_of :interval_modifier, :if => "interval_unit == RecurringTask::INTERVAL_MONTH"
+  validates_presence_of :interval_modifier, :if => "interval_unit == RecurringTask::INTERVAL_MONTH || interval_unit == RecurringTask::INTERVAL_DAY"
 
   validates_presence_of :interval_number
   
@@ -56,6 +66,10 @@ class RecurringTask < ActiveRecord::Base
     :in => RecurringTask::MONTH_MODIFIERS_LOCALIZED.keys,
     :message => "#{l(:error_invalid_modifier)} '%{value}' (Validation)",
     :if => "interval_unit == RecurringTask::INTERVAL_MONTH"
+  validates_inclusion_of :interval_modifier,
+    :in => RecurringTask::DAY_MODIFIERS_LOCALIZED.keys,
+    :message => "#{l(:error_invalid_modifier)} '%{value}' (Validation)",
+    :if => "interval_unit == RecurringTask::INTERVAL_DAY"
   
   validates_numericality_of :interval_number, :only_integer => true, :greater_than => 0
   # cannot validate presence of issue if want to use other features; requiring presence of fixed_schedule requires it to be true
@@ -123,7 +137,7 @@ class RecurringTask < ActiveRecord::Base
     if new_record?
       @interval_localized_modifier
     else
-      modifiers_names = get_modifiers_descriptions
+      modifiers_names = month_modifiers_descriptions
       if modifiers_names.has_key?(interval_modifier)
         modifiers_names[interval_modifier]
        else
@@ -151,7 +165,7 @@ class RecurringTask < ActiveRecord::Base
  # end
   
   #41
-  def get_modifiers_descriptions
+  def month_modifiers_descriptions
     prev_date = previous_date_for_recurrence
     days_to_eom = (prev_date.end_of_month.mday - prev_date.mday + 1).to_i
     #print days_to_eom, " ", prev_date.end_of_month
@@ -163,6 +177,10 @@ class RecurringTask < ActiveRecord::Base
       :dows_to_eom => (((prev_date.end_of_month.mday - prev_date.mday).to_i / 7) + 1).ordinalize,
     }
     Hash[MONTH_MODIFIERS_LOCALIZED.map{|k,v| [k, v % values]}]
+  end
+
+  def day_modifiers_descriptions
+    DAY_MODIFIERS_LOCALIZED
   end
   
   
@@ -187,7 +205,14 @@ class RecurringTask < ActiveRecord::Base
       # previous_date_for_recurrence + recurrence_pattern #41
       case interval_unit
       when INTERVAL_DAY
-        (prev_date + interval_number.days).to_date
+        case interval_modifier
+        when DAY_MODIFIER_ALL
+          (prev_date + interval_number.days).to_date
+        when DAY_MODIFIER_WORKING_DAYS
+          add_working_days prev_date, interval_number
+        else
+          raise "#{l(:error_invalid_interval)} #{interval_unit} (next_scheduled_recurrence)"
+        end
       when INTERVAL_WEEK
         (prev_date + interval_number.weeks).to_date
       when INTERVAL_MONTH

--- a/app/views/recurring_tasks/_form.html.erb
+++ b/app/views/recurring_tasks/_form.html.erb
@@ -1,3 +1,8 @@
+<% content_for :header_tags do %>
+  <%= javascript_include_tag 'recurring_tasks.js', :plugin => 'recurring_tasks' %>
+  <%= stylesheet_link_tag 'recurring_tasks.css', :plugin => 'recurring_tasks'%>
+<% end %>
+
 <%= labelled_form_for rt, :url => { :action => next_step, :id=>rt } do |f| %>
 <div class="box tabular"> 
     <%= error_messages_for 'recurring_task' %>
@@ -6,11 +11,9 @@
     
     
     <p><%= f.number_field :interval_number, :required => true, :size => 4, :maxlength => 4 %></p>
-    <p><%= f.select :interval_unit, @interval_units, {:prompt => l(:field_please_select), :required => true}, :onChange =>"document.getElementById('interval_modifier_block').style.display=(this.value=='"+ RecurringTask::INTERVAL_MONTH + "' ? 'block' : 'none')" %></p>
-    <% modifier_display = (rt.interval_unit == RecurringTask::INTERVAL_MONTH) ? "display:inline" : "display:none" %>
-    <%= content_tag :div, :id => "interval_modifier_block", :style => modifier_display do -%>
-      <p><%= f.select 'interval_modifier', rt.get_modifiers_descriptions.collect{|k,v| [v, k]} %></p>
-    <% end -%>
+    <p><%= f.select :interval_unit, @interval_units, {:prompt => l(:field_please_select), :required => true} %></p>
+    <p class='day_interval_modifier'><%= f.select 'interval_modifier', rt.day_modifiers_descriptions.collect{|k,v| [v, k]}, {}, :disabled => true %></p>
+    <p class='month_interval_modifier'><%= f.select 'interval_modifier', rt.month_modifiers_descriptions.collect{|k,v| [v, k]}, {}, :disabled => true %></p>
     <p><%= f.check_box :fixed_schedule %></p>
   </div>
   <%= f.submit %>

--- a/assets/javascripts/recurring_tasks.js
+++ b/assets/javascripts/recurring_tasks.js
@@ -1,0 +1,28 @@
+$(document).on('change', 'select#recurring_task_interval_unit', onUnitChanged);
+
+$(document).ready(function() {
+  updateIntervalModifier($('select#recurring_task_interval_unit').val());
+});
+
+function onUnitChanged(event) {
+  updateIntervalModifier($(this).val());
+}
+
+function updateIntervalModifier(unit) {
+  if (unit == 'd') {
+    $('.day_interval_modifier select').prop('disabled', false);
+    $('.day_interval_modifier').show();
+  } else {
+    $('.day_interval_modifier select').prop('disabled', true);
+    $('.day_interval_modifier').hide();
+  }
+
+  if (unit == 'm') {
+    $('.month_interval_modifier select').prop('disabled', false);
+    $('.month_interval_modifier').show();
+  } else {
+    $('.month_interval_modifier select').prop('disabled', true);
+    $('.month_interval_modifier').hide();
+  }
+}
+

--- a/assets/stylesheets/recurring_tasks.css
+++ b/assets/stylesheets/recurring_tasks.css
@@ -1,0 +1,7 @@
+.day_interval_modifier {
+  display: none;
+}
+
+.month_interval_modifier {
+  display: none;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,9 @@ en:
   interval_month: "month"
   interval_year:  "year"
 
+  day_modifier_all: "every day"
+  day_modifier_working_days: "working days"
+
   month_modifier_day_from_first: "on %{days_from_bom} day"
   month_modifier_day_to_last: "on %{days_to_eom} to last day"
   month_modifier_dow_from_first: "on %{dows_from_bom} %{day_of_week}"

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,0 +1,11 @@
+development:
+  adapter: mysql2
+  database: redmine_development
+  host: localhost
+  encoding: utf8
+
+test:
+  adapter: mysql2
+  database: redmine_test
+  host: localhost
+  encoding: utf8

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -1,0 +1,11 @@
+fixed_daily_recurrence:
+  subject: daily fixed recurrence
+  tracker_id: 1
+  project_id: 1
+  status_id: 1
+  priority_id: 4
+  author_id: 1
+  lft: 1
+  rgt: 2
+  start_date: <%= 2.days.ago.to_s(:db) %>
+  due_date: <%= 1.day.ago.to_s(:db) %>

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -1,5 +1,5 @@
-fixed_daily_recurrence:
-  subject: daily fixed recurrence
+basic_issue:
+  subject: basic issue
   tracker_id: 1
   project_id: 1
   status_id: 1

--- a/test/fixtures/recurring_tasks.yml
+++ b/test/fixtures/recurring_tasks.yml
@@ -1,0 +1,6 @@
+fixed_daily_recurrence:
+  issue: fixed_daily_recurrence
+  fixed_schedule: true
+  interval_modifier: mdff
+  interval_number: 1
+  interval_unit: d

--- a/test/fixtures/recurring_tasks.yml
+++ b/test/fixtures/recurring_tasks.yml
@@ -1,6 +1,13 @@
 fixed_daily_recurrence:
-  issue: fixed_daily_recurrence
+  issue: basic_issue
   fixed_schedule: true
-  interval_modifier: mdff
   interval_number: 1
   interval_unit: d
+  interval_modifier: da
+
+fixed_working_day_recurrence:
+  issue: basic_issue
+  fixed_schedule: true
+  interval_number: 1
+  interval_unit: d
+  interval_modifier: dwd

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,24 @@
+require File.expand_path(File.dirname(__FILE__) + '/../redmine/test/test_helper')
+
+module Redmine
+  module PluginFixturesLoader
+    def fixture(name)
+      ActiveRecord::FixtureSet.identify name
+    end
+
+    def self.included(base)
+      base.class_eval do
+        def self.plugin_fixtures(*symbols)
+          ActiveRecord::FixtureSet.create_fixtures(File.dirname(__FILE__) + '/fixtures/', symbols)
+        end
+      end
+    end
+  end
+end
+
+module ActiveSupport
+  class TestCase
+    include Redmine::PluginFixturesLoader
+    self.use_transactional_fixtures = true
+  end
+end

--- a/test/unit/recurring_task_test.rb
+++ b/test/unit/recurring_task_test.rb
@@ -16,4 +16,17 @@ class RecurringTaskTest < ActiveSupport::TestCase
       task.recur_issue_if_needed!
     end
   end
+
+  def test_working_day_recurrence
+    task = RecurringTask.find fixture(:fixed_working_day_recurrence)
+    issue = Issue.find fixture(:basic_issue)
+    issue.update start_date: Date.today.beginning_of_week-3.weeks,
+                 due_date: Date.today.beginning_of_week-3.weeks+1.day
+
+    Timecop.freeze(Date.today.beginning_of_week) do
+      assert_difference -> { Issue.count }, 15 do
+        task.recur_issue_if_needed!
+      end
+    end
+  end
 end

--- a/test/unit/recurring_task_test.rb
+++ b/test/unit/recurring_task_test.rb
@@ -1,0 +1,19 @@
+require_relative '../test_helper.rb'
+
+class RecurringTaskTest < ActiveSupport::TestCase
+  plugin_fixtures :issues, :recurring_tasks
+  fixtures :projects, :users, :roles, :trackers, :projects_trackers,
+           :issue_statuses, :enumerations, :enabled_modules
+
+  def setup
+    RecurringTask.any_instance.stubs :puts
+  end
+
+  def test_daily_recurrence
+    task = RecurringTask.find fixture(:fixed_daily_recurrence)
+
+    assert_difference -> { Issue.count }, 2 do
+      task.recur_issue_if_needed!
+    end
+  end
+end


### PR DESCRIPTION
This might be a pretty specific feature that will overcomplicate the plugin for the average user. But I'd wanted to offer the code to you anyways so you can consider yourself whether you think this belongs in the plugin or not.

For  our usecase we need some issues to occur on weekdays only. Redmine has helpers to work with weekdays so the core feature was quickly build. However because of the way the month_interval_modifiers are setup it got a bit more complex. It might be worth it to look at a cleaner way to setup the modifiers in the future, especially if other units are going to get modifiers as well.

ps: the first commit in this PR (226c64f) is written on a separate branch with it's own PR, so this is about the changes in 3b52382