### PR TITLE
Empties closed_on date on copied issues.

### DIFF
--- a/app/models/recurring_task.rb
+++ b/app/models/recurring_task.rb
@@ -276,6 +276,7 @@ class RecurringTask < ActiveRecord::Base
           subtask.due_date = subtask.start_date + subtask_timespan
           subtask.done_ratio = 0
           subtask.status = recurring_issue_default_status
+          subtask.closed_on = nil
           subtask.save!
         end
 
@@ -286,6 +287,7 @@ class RecurringTask < ActiveRecord::Base
       new_issue.start_date = new_issue.due_date - timespan
       new_issue.done_ratio = 0
       new_issue.status = recurring_issue_default_status
+      new_issue.closed_on = nil
       new_issue.save!
 
       puts "#{l(:recurring_task_created)} #{issue.id}: #{issue.subj_date} => #{new_issue.id}: #{new_issue.subj_date}"

--- a/test/unit/recurring_task_test.rb
+++ b/test/unit/recurring_task_test.rb
@@ -16,4 +16,14 @@ class RecurringTaskTest < ActiveSupport::TestCase
       task.recur_issue_if_needed!
     end
   end
+
+  def test_removes_closed_on
+    task = RecurringTask.find fixture(:fixed_daily_recurrence)
+    task.issue.status = IssueStatus.find_by(name: "Closed")
+    task.issue.save
+
+    assert_not_nil task.issue.closed_on
+    task.recur_issue_if_needed!
+    assert_nil task.issue.closed_on
+  end
 end


### PR DESCRIPTION
Copied issues are reset to an open issue-state but the closed_on datestamp is never wiped, this PR fixes that and adds a test to prove it works.